### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/elbatourib/be7ced8c-04bb-40d4-95ab-f01bca7ae175/8f3806ed-aa81-4229-8825-4ba7bb27610b/_apis/work/boardbadge/6d79c789-8d59-458c-b2d7-9a5d21b3dee0)](https://dev.azure.com/elbatourib/be7ced8c-04bb-40d4-95ab-f01bca7ae175/_boards/board/t/8f3806ed-aa81-4229-8825-4ba7bb27610b/Microsoft.RequirementCategory)
 # Personal-Portfolio
 My personal portfolio


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/elbatourib/be7ced8c-04bb-40d4-95ab-f01bca7ae175/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.